### PR TITLE
fix RFC8941 boolean value

### DIFF
--- a/rocket/src/main.rs
+++ b/rocket/src/main.rs
@@ -12,6 +12,6 @@ fn index() -> &'static str {
 fn rocket() -> _ {
     rocket::build().mount("/", routes![index])
         .attach(AdHoc::on_response("Add Request-OTR header", |_req, response| Box::pin(async move {
-            response.set_header(Header::new("Request-OTR", "1"));
+            response.set_header(Header::new("Request-OTR", "?1"));
         })))
 }


### PR DESCRIPTION
According to https://www.rfc-editor.org/rfc/rfc8941#name-booleans  boolean values should be prefixed with "?"

The header spec example shows this usage as well: https://ietf.org/archive/id/draft-sahib-httpbis-off-the-record-00.html#name-request-otr-response-header-2